### PR TITLE
Change output file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ vcs: git
 format: md
 issue_tracker_pattern: http://some.issue.tracker.com/\1
 break: "## Changelog"
+output_file_name: "README.md"
 message_groups:
   Features:
     - feature

--- a/readmegen
+++ b/readmegen
@@ -19,7 +19,7 @@ if (!$loaded) {
 }
 
 if (2 > count($argv)) {
-    die('Example usage: php generate.php --from <tag / commit> --release <release number>');
+    die("Example usage: php generate.php --from <tag / commit> --release <release number>\n");
 }
 
 new \ReadmeGen\Bootstrap($argv);

--- a/readmegen.yml
+++ b/readmegen.yml
@@ -2,6 +2,7 @@ vcs: git
 format: md
 issue_tracker_pattern: http://some.issue.tracker.com/\1
 break: "## Changelog"
+output_file_name: "README.md"
 message_groups:
   Features:
     - feature

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -49,7 +49,9 @@ class Bootstrap
         // Create the output formatter
         $formatter = new $formatterClassName;
 
-        $formatter->setRelease($options['release'])
+        $formatter
+            ->setRelease($options['release'])
+            ->setFileName($config['output_file_name'])
             ->setDate($this->getToDate());
 
         // Pass decorated log entries to the generator


### PR DESCRIPTION
Currently output file name is hardcoded. This PR add new parameter in 'readmegen.yml' that allow specify output file name. By default it have the same value - 'README.md'. So it shouldn't break existing installations.