### PR TITLE
fix: git parsing by only parsing the subject of each commit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ulrichsg/getopt-php": "2.*"
     },
     "require-dev": {
-        "phpspec/phpspec": "dev-master"
+        "phpspec/phpspec": "^2.5"
     },
     "config": {
         "bin-dir": "bin"

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "phpspec/phpspec": "^2.5"
     },
     "config": {
+        "platform": {"php": "5.3.9"},
         "bin-dir": "bin"
     },
     "bin": [

--- a/spec/ReadmeGenSpec.php
+++ b/spec/ReadmeGenSpec.php
@@ -5,7 +5,6 @@ namespace spec\ReadmeGen {
     use PhpSpec\ObjectBehavior;
     use \ReadmeGen\Config\Loader as ConfigLoader;
     use \ReadmeGen\Shell;
-    use \ReadmeGen\Vcs\Type\Git;
     use \ReadmeGen\Log\Extractor;
     use \ReadmeGen\Log\Decorator;
     use \ReadmeGen\Output\Format\Md;
@@ -72,6 +71,7 @@ namespace spec\ReadmeGen {
 
         function it_runs_the_whole_process(Shell $shell)
         {
+            $shell->beADoubleOf('ReadmeGen\Shell');
             file_put_contents($this->gitConfigFile, $this->gitConfig);
 
             $shell->run('git log --pretty=format:"%s" 1.2.3..4.0.0')->willReturn($this->getLogAsString());
@@ -85,10 +85,10 @@ namespace spec\ReadmeGen {
             ));
             $this->getParser()->setShellRunner($shell);
 
-            $log = $this->getParser()->parse();
+            $this->getParser()->parse();
 
             $this->setExtractor(new Extractor());
-            $logGrouped = $this->extractMessages($log)->shouldReturn(array(
+            $logGrouped = $this->extractMessages($this->getLogAsArray())->shouldReturn(array(
                 'Features' => array(
                     'bar baz #123',
                     'dummy feature',
@@ -122,9 +122,9 @@ namespace spec\ReadmeGen {
             $this->writeOutput()->shouldReturn(true);
         }
 
-        protected function getLogAsString()
+        protected function getLogAsArray()
         {
-            $log = array(
+            return array(
                 'foo',
                 'feature: bar baz #123',
                 'nope',
@@ -133,8 +133,11 @@ namespace spec\ReadmeGen {
                 'also nope',
                 'fix: some bugfix',
             );
+        }
 
-            return join(Git::MSG_SEPARATOR."\n", $log).Git::MSG_SEPARATOR."\n";
+        protected function getLogAsString()
+        {
+            return join("\n", $this->getLogAsArray())."\n";
         }
 
     }

--- a/spec/ReadmeGenSpec.php
+++ b/spec/ReadmeGenSpec.php
@@ -74,7 +74,7 @@ namespace spec\ReadmeGen {
         {
             file_put_contents($this->gitConfigFile, $this->gitConfig);
 
-            $shell->run(sprintf('git log --pretty=format:"%%s%s%%b" 1.2.3..4.0.0', Git::MSG_SEPARATOR))->willReturn($this->getLogAsString());
+            $shell->run('git log --pretty=format:"%s" 1.2.3..4.0.0')->willReturn($this->getLogAsString());
 
             $this->beConstructedWith(new ConfigLoader, $this->gitConfigFile, true);
 

--- a/spec/Vcs/Type/GitSpec.php
+++ b/spec/Vcs/Type/GitSpec.php
@@ -40,24 +40,24 @@ class GitSpec extends ObjectBehavior
     function it_should_add_options_and_arguments_to_the_command(Shell $shell)
     {
         $log = sprintf("Foo bar.%s\nDummy message.%s\n\n", Git::MSG_SEPARATOR, Git::MSG_SEPARATOR);
-        $shell->run(sprintf('git log --pretty=format:"%%s%s%%b"', Git::MSG_SEPARATOR))->willReturn($log);
+        $shell->run('git log --pretty=format:"%s"')->willReturn($log);
         
         $this->setShellRunner($shell);
         
         $this->setOptions(array('x', 'y'));
         $this->setArguments(array('foo' => 'bar', 'baz' => 'wat', 'from' => '1.0'));
         
-        $this->getCommand()->shouldReturn('git log --pretty=format:"%s'.Git::MSG_SEPARATOR.'%b" 1.0..HEAD --x --y');
+        $this->getCommand()->shouldReturn('git log --pretty=format:"%s" 1.0..HEAD --x --y');
     }
 
     function it_should_properly_include_the_from_and_to_arguments() {
         $this->setOptions(array('x', 'y'));
 
         $this->setArguments(array('from' => '3.4.5', 'foo' => 'bar'));
-        $this->getCommand()->shouldReturn('git log --pretty=format:"%s'.Git::MSG_SEPARATOR.'%b" 3.4.5..HEAD --x --y');
+        $this->getCommand()->shouldReturn('git log --pretty=format:"%s" 3.4.5..HEAD --x --y');
 
         $this->setArguments(array('from' => '3.4.5', 'foo' => 'bar', 'to' => '4.0'));
-        $this->getCommand()->shouldReturn('git log --pretty=format:"%s'.Git::MSG_SEPARATOR.'%b" 3.4.5..4.0 --x --y');
+        $this->getCommand()->shouldReturn('git log --pretty=format:"%s" 3.4.5..4.0 --x --y');
     }
 
     function it_returns_the_date_of_the_commit(Shell $shell) {

--- a/src/Log/Extractor.php
+++ b/src/Log/Extractor.php
@@ -24,9 +24,9 @@ class Extractor {
     /**
      * Message groups as a string.
      *
-     * @var string
+     * @var array
      */
-    protected $messageGroupsJoined;
+    protected $messageGroupsJoined = array();
 
     /**
      * Grouped messages.
@@ -78,6 +78,7 @@ class Extractor {
 
                 if (preg_match($pattern, $line)) {
                     $this->appendToGroup($header, $line, $pattern);
+                    break;
                 }
             }
         }

--- a/src/Vcs/Type/Git.php
+++ b/src/Vcs/Type/Git.php
@@ -11,7 +11,7 @@ class Git extends AbstractType
      */
     public function parse()
     {
-        return array_filter(array_map('trim', explode(self::MSG_SEPARATOR, $this->getLog())));
+        return array_filter(array_map('trim', explode(self::MSG_SEPARATOR, $this->getLog(), 2)));
     }
 
     /**

--- a/src/Vcs/Type/Git.php
+++ b/src/Vcs/Type/Git.php
@@ -2,6 +2,8 @@
 
 class Git extends AbstractType
 {
+    const MSG_SEPARATOR = "\n";
+
     /**
      * Parses the log.
      *
@@ -19,7 +21,7 @@ class Git extends AbstractType
      */
     protected function getBaseCommand()
     {
-        return 'git log --pretty=format:"%s{{MSG_SEPARATOR}}%b"';
+        return 'git log --pretty=format:"%s"';
     }
 
     /**


### PR DESCRIPTION
- Generally the subject is the first line.  This fixes issues where the strings are matched in the middle of the long messages.  The separator was splitting the commit messages in half so the subject was at the end of the previous commit message.
- Stop checking groups once one is found for a commit. (small optimization)
- Fix type for $messageGroupsJoined