### PR TITLE
fix: Ignore the body of the git commit message

### DIFF
--- a/src/Vcs/Type/Git.php
+++ b/src/Vcs/Type/Git.php
@@ -19,7 +19,7 @@ class Git extends AbstractType
      */
     protected function getBaseCommand()
     {
-        return 'git log --pretty=format:"%s{{MSG_SEPARATOR}}%b"';
+        return 'git log --pretty=format:"%s{{MSG_SEPARATOR}}"';
     }
 
     /**


### PR DESCRIPTION
Ignore the body of a commit message so that the commit after it is not ignored by the parser
Github issue #29 and #4 